### PR TITLE
Allow cloning inside portable folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+LibreWolf-Portable.exe
+LibreWolf-WinUpdater.exe
+LibreWolf-WinUpdater.ini
+LibreWolf/
+Profiles/
+ScheduledTask-Create.ps1
+ScheduledTask-Remove.ps1


### PR DESCRIPTION
This PR simply adds a .gitignore that makes cloning the repository into the same folder as the portable application more convenient. This way, as someone updates their settings or modifies the optimizer they'll be able to self-deliver those updates really easily.